### PR TITLE
:fire: Hide apidoc entry

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -77,7 +77,7 @@
 ## Anlagen
 
 1. [Glossar](anhang/GLOSSARY.md)
-1. [HTTP-REST-API](andere-themen/cheat-sheet/http-rest-api/README.md)
+<!-- 1. [HTTP-REST-API](andere-themen/cheat-sheet/http-rest-api/README.md) -->
 1. [Messagebus-API](andere-themen/cheat-sheet/messagebus/README.md)
   * [internal](andere-themen/cheat-sheet/messagebus/internal/README.md)
   * [external](andere-themen/cheat-sheet/messagebus/external/README.md)


### PR DESCRIPTION
## What did you change?

This PR hides the HTTP-REST-API entry on the gitbook menu.

## How can others test the changes?

- npm i
- npm start

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [x] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [x] I've mentioned all **PRs, which relate to this one**
