### PR TITLE
📝 :memo: Link to TypeScript README Instead of Installation Instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ unterschiedliche Einsatzszenarien eignen.
 
 #### Weiterführende Links
 
-* [TypeScript-Implementierung](./getting-started/installation.md)
+* [TypeScript-Implementierung](./processengine/typescript/README.md)
 * .NET-Implementierung (Bereits veröffentlicht, Dokumentation fehlt zurzeit)
 
 ### ProcessEngine APIs {#apis}


### PR DESCRIPTION
## What did you change?

Link TypeScript-Implementierung to `./processengine/typescript/README.md` instead `./getting-started/installation.md`.

Fixes #104.

## How can others test the changes?

- Read.
- Jenkins will assert that the link is ok.

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [x] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [x] I've mentioned all **PRs, which relate to this one**
